### PR TITLE
Bugfix: Unngå "null" string i utbetalingmelding

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/utbetal/helved/TilkjentYtelseExt.kt
+++ b/app/src/main/kotlin/no/nav/aap/utbetal/helved/TilkjentYtelseExt.kt
@@ -6,6 +6,7 @@ import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelseAvvent
 import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelsePeriode
 import no.nav.aap.utbetal.utbetaling.MeldeperiodeUtbetalingIdMap
 import no.nav.aap.utbetaling.helved.toBase64
+import org.jetbrains.annotations.VisibleForTesting
 import java.time.LocalDate
 
 fun TilkjentYtelse.tilUtbetalingMelding(meldeperiodeUtbetalingMap: MeldeperiodeUtbetalingIdMap): UtbetalingMelding {
@@ -22,11 +23,12 @@ fun TilkjentYtelse.tilUtbetalingMelding(meldeperiodeUtbetalingMap: MeldeperiodeU
     return utbetalingMelding
 }
 
-private fun TilkjentYtelseAvvent.tilAvvent() =
+@VisibleForTesting
+internal fun TilkjentYtelseAvvent.tilAvvent() =
     Avvent(
         fom = this.fom.toString(),
         tom = this.tom.toString(),
-        overføres = this.overføres.toString(),
+        overføres = this.overføres?.toString(),
         årsak = this.årsak?.toString()
     )
 

--- a/app/src/main/kotlin/no/nav/aap/utbetal/helved/TilkjentYtelseExt.kt
+++ b/app/src/main/kotlin/no/nav/aap/utbetal/helved/TilkjentYtelseExt.kt
@@ -6,6 +6,7 @@ import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelseAvvent
 import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelsePeriode
 import no.nav.aap.utbetal.utbetaling.MeldeperiodeUtbetalingIdMap
 import no.nav.aap.utbetaling.helved.toBase64
+import org.jetbrains.annotations.VisibleForTesting
 import java.time.LocalDate
 
 fun TilkjentYtelse.tilUtbetalingMelding(meldeperiodeUtbetalingMap: MeldeperiodeUtbetalingIdMap): UtbetalingMelding {
@@ -22,11 +23,12 @@ fun TilkjentYtelse.tilUtbetalingMelding(meldeperiodeUtbetalingMap: MeldeperiodeU
     return utbetalingMelding
 }
 
-private fun TilkjentYtelseAvvent.tilAvvent() =
+@VisibleForTesting
+internal fun TilkjentYtelseAvvent.tilAvvent() =
     Avvent(
         fom = this.fom.toString(),
         tom = this.tom.toString(),
-        overføres = this.overføres.toString(),
+        overføres = this.overføres?.toString(),
         årsak = this.årsak?.toString(),
         feilregistrering = this.feilregistrering,
     )

--- a/app/src/main/kotlin/no/nav/aap/utbetal/tilkjentytelse/TilkjentYtelse.kt
+++ b/app/src/main/kotlin/no/nav/aap/utbetal/tilkjentytelse/TilkjentYtelse.kt
@@ -31,7 +31,7 @@ data class TilkjentYtelsePeriode(
 data class TilkjentYtelseAvvent(
     val fom: LocalDate,
     val tom: LocalDate,
-    val overføres: LocalDate?,
+    val overføres: LocalDate? = null,
     val årsak: AvventÅrsak? = null,
     val feilregistrering: Boolean = false,
 )

--- a/app/src/test/kotlin/no/nav/aap/utbetal/helved/TilkjentYtelseExtTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/utbetal/helved/TilkjentYtelseExtTest.kt
@@ -6,7 +6,9 @@ import no.nav.aap.komponenter.verdityper.Beløp
 import no.nav.aap.komponenter.verdityper.GUnit
 import no.nav.aap.komponenter.verdityper.Prosent
 import no.nav.aap.utbetal.felles.YtelseDetaljer
+import no.nav.aap.utbetal.kodeverk.AvventÅrsak
 import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelse
+import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelseAvvent
 import no.nav.aap.utbetal.tilkjentytelse.TilkjentYtelsePeriode
 import no.nav.aap.utbetal.utbetaling.MeldeperiodeUtbetalingIdMap
 import org.assertj.core.api.Assertions.assertThat
@@ -189,6 +191,54 @@ class TilkjentYtelseExtTest {
         assertThat(melding.beslutter).isEqualTo("beslutter1")
         assertThat(melding.vedtakstidspunktet).isEqualTo(vedtakstidspunkt)
         assertThat(melding.avvent).isNull()
+    }
+
+    @Test
+    fun `tilAvvent mapper felter korrekt`() {
+        val fom = "2026-04-01"
+        val tom = "2026-04-14"
+        val overføres = "2026-04-15"
+        val årsak = "AVVENT_AVREGNING"
+        val feilregistrering = false
+
+        val tilkjentYtelseAvvent = TilkjentYtelseAvvent(
+            fom = LocalDate.parse(fom),
+            tom = LocalDate.parse(tom),
+            overføres = LocalDate.parse(overføres),
+            AvventÅrsak.valueOf(årsak),
+            feilregistrering
+        )
+
+        val avvent = tilkjentYtelseAvvent.tilAvvent()
+
+        assertThat(avvent.fom).isEqualTo(fom)
+        assertThat(avvent.tom).isEqualTo(tom)
+        assertThat(avvent.overføres).isEqualTo(overføres)
+        assertThat(avvent.årsak).isEqualTo(årsak)
+        assertThat(avvent.feilregistrering).isEqualTo(feilregistrering)
+    }
+
+    @Test
+    fun `tilAvvent med nullverdier mapper felter korrekt`() {
+        val fom = "2026-04-01"
+        val tom = "2026-04-14"
+        val feilregistrering = false
+
+        val tilkjentYtelseAvvent = TilkjentYtelseAvvent(
+            fom = LocalDate.parse(fom),
+            tom = LocalDate.parse(tom),
+            overføres = null,
+            årsak = null,
+            feilregistrering
+        )
+
+        val avvent = tilkjentYtelseAvvent.tilAvvent()
+
+        assertThat(avvent.fom).isEqualTo(fom)
+        assertThat(avvent.tom).isEqualTo(tom)
+        assertThat(avvent.overføres).isNull()
+        assertThat(avvent.årsak).isNull()
+        assertThat(avvent.feilregistrering).isEqualTo(feilregistrering)
     }
 
     private fun lagTilkjentYtelse(perioder: List<TilkjentYtelsePeriode>): TilkjentYtelse {


### PR DESCRIPTION
Bugfix: Unngå å mappe null verdi til "null" string i avvent.overføres verdien i utbetalingmelding.