### PR TITLE
Logg feil og forsinkelser med error og warning nivå ved aksjonsbehov

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     implementation(libs.logstashLogbackEncoder)
     implementation(libs.kafkaClients)
 
+    implementation("no.bekk.bekkopen:nocommons:0.17.0")
+
     implementation(project(":dbflyway"))
     implementation(project(":api-kontrakt"))
     implementation(libs.hikari)

--- a/app/src/main/kotlin/no/nav/aap/utbetal/server/prosessering/SjekkKvitteringFraØkonomiUtfører.kt
+++ b/app/src/main/kotlin/no/nav/aap/utbetal/server/prosessering/SjekkKvitteringFraØkonomiUtfører.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.utbetal.server.prosessering
 
+import no.bekk.bekkopen.date.NorwegianDateUtil.isWorkingDay
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.motor.Jobb
 import no.nav.aap.motor.JobbInput
@@ -8,11 +9,14 @@ import no.nav.aap.motor.cron.CronExpression
 import no.nav.aap.utbetal.klienter.helved.UtbetalingKlient
 import no.nav.aap.utbetal.klienter.helved.UtbetalingRestKlient
 import no.nav.aap.utbetal.utbetaling.KvitteringService
+import no.nav.aap.utbetal.utbetaling.UtbetalingLight
 import no.nav.aap.utbetal.utbetaling.UtbetalingRepository
 import no.nav.aap.utbetaling.UtbetalingStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.*
 import kotlin.time.measureTime
 
 class SjekkKvitteringFraØkonomiUtfører(private val connection: DBConnection, private val utbetalingKlient: UtbetalingKlient): JobbUtfører {
@@ -21,17 +25,46 @@ class SjekkKvitteringFraØkonomiUtfører(private val connection: DBConnection, p
 
     override fun utfør(input: JobbInput) {
         val utbetalingerSomManglerKvitteringer = UtbetalingRepository(connection).hentUtbetalingerSomManglerKvittering()
-        val sendtMenManglerKvittering = utbetalingerSomManglerKvitteringer.count {it.utbetalingStatus == UtbetalingStatus.SENDT}
-        val feiletStatus = utbetalingerSomManglerKvitteringer.count {it.utbetalingStatus == UtbetalingStatus.FEILET}
-        val for10MinutterSiden = LocalDateTime.now().minusMinutes(10)
-        val antallUtbetalingMedForsinkedeKvitteringer = utbetalingerSomManglerKvitteringer.count {it.utbetalingOpprettet < for10MinutterSiden  }
-        log.info("Mangler kvitteringer på $sendtMenManglerKvittering utbetalinger. Antall som er mer enn 10 minutter gamle: $antallUtbetalingMedForsinkedeKvitteringer")
-        log.info("Feilet status på $feiletStatus utbetalinger")
+
+        loggForsinkelserOgFeil(utbetalingerSomManglerKvitteringer)
+
         val kvitteringService = KvitteringService(connection, utbetalingKlient)
         val tid = measureTime {
             utbetalingerSomManglerKvitteringer.forEach { kvitteringService.sjekkKvittering(it) }
         }
-        log.info("Henting av kvittering for ${sendtMenManglerKvittering + feiletStatus} utbetalinger tok $tid")
+        log.info("Henting av kvittering for ${utbetalingerSomManglerKvitteringer.size} utbetalinger tok $tid")
+    }
+
+    private fun loggForsinkelserOgFeil(ukvitterteUtbetalinger: List<UtbetalingLight>) {
+        val antallForsinket = ukvitterteUtbetalinger.count {it.utbetalingStatus == UtbetalingStatus.SENDT}
+        val antallFeilet = ukvitterteUtbetalinger.count {it.utbetalingStatus == UtbetalingStatus.FEILET}
+
+        val for10MinutterSiden = LocalDateTime.now().minusMinutes(10)
+        val antallForsinketMerEnn10Minutter = ukvitterteUtbetalinger.count {it.utbetalingOpprettet < for10MinutterSiden  }
+
+        if (antallForsinketMerEnn10Minutter > 0 && erForsinkelsenIVakttid()) {
+            log.error("Mangler kvitteringer på $antallForsinket utbetalinger. Antall som er mer enn 10 minutter gamle: $antallForsinketMerEnn10Minutter")
+        } else {
+            log.info("Mangler kvitteringer på $antallForsinket utbetalinger. Antall som er mer enn 10 minutter gamle: $antallForsinketMerEnn10Minutter")
+        }
+        if (antallFeilet > 0) {
+            val saksnummereForFeilet = ukvitterteUtbetalinger.filter { it.utbetalingStatus == UtbetalingStatus.FEILET }.map { it.saksnummer }
+            log.error("Feilet status på $antallFeilet utbetalinger. Rapporter saksnummer(e) til #team-hel-ved. Saker: $saksnummereForFeilet")
+        } else {
+            log.info("Feilet status på $antallFeilet utbetalinger")
+        }
+    }
+
+    /* Det er normalt med kvitteringsforsinkelser utenom åpningstiden til NAVs økonomisystem
+    *  Åpningstiden er 06:00 til 21:00, men vi setter kun error level i vakt-tid 9 til 15. Vi tar dermed
+    *  også høyde for etterslepet fra 6 til rundt 9 i kvitteringsleveransen fra Økonomi hver morgen.
+    * */
+    private fun erForsinkelsenIVakttid(): Boolean {
+        val idag = Date()
+        val klokkeslett = LocalTime.now()
+        val start = LocalTime.of(9, 0)
+        val stopp = LocalTime.of(15, 0)
+        return isWorkingDay(idag) && klokkeslett.isAfter(start) && klokkeslett.isBefore(stopp)
     }
 
     companion object: Jobb {

--- a/app/src/main/kotlin/no/nav/aap/utbetal/server/prosessering/SjekkKvitteringFraØkonomiUtfører.kt
+++ b/app/src/main/kotlin/no/nav/aap/utbetal/server/prosessering/SjekkKvitteringFraØkonomiUtfører.kt
@@ -43,7 +43,7 @@ class SjekkKvitteringFraØkonomiUtfører(private val connection: DBConnection, p
         val antallForsinketMerEnn10Minutter = ukvitterteUtbetalinger.count {it.utbetalingOpprettet < for10MinutterSiden  }
 
         if (antallForsinketMerEnn10Minutter > 0 && erForsinkelsenIVakttid()) {
-            log.error("Mangler kvitteringer på $antallForsinket utbetalinger. Antall som er mer enn 10 minutter gamle: $antallForsinketMerEnn10Minutter")
+            log.warn("Mangler kvitteringer på $antallForsinket utbetalinger. Antall som er mer enn 10 minutter gamle: $antallForsinketMerEnn10Minutter")
         } else {
             log.info("Mangler kvitteringer på $antallForsinket utbetalinger. Antall som er mer enn 10 minutter gamle: $antallForsinketMerEnn10Minutter")
         }


### PR DESCRIPTION
- Øk log-level til warning for >10min forsinkelser på kvitteringer i arbeidstid
- Øk log-level til error for feil i utbetaling som skal rapporteres til Hel-ved
- Logg saksnummer i app-logg for rapportering til Hel-ved ved feil i utbetaling