### PR TITLE
fix(ci): prevent deploy cancellations when merging concurrent PRs

### DIFF
--- a/.github/workflows/deploy-kafka.yaml
+++ b/.github/workflows/deploy-kafka.yaml
@@ -8,6 +8,11 @@ on:
             - kafka/**
             - .github/workflows/deploy-kafka.yaml
             - '!kafka/README.md'
+
+concurrency:
+    group: deploy-kafka
+    queue: max
+
 jobs:
     setup-matrix:
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
             packages: write
             id-token: write
         runs-on: ubuntu-latest
+        concurrency:
+            group: publiser-kontrakt
+            queue: max
         steps:
             - uses: actions/checkout@v7
               with:
@@ -85,7 +88,9 @@ jobs:
             id-token: write
         needs: gradle
         uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
-        concurrency: deploy-dev
+        concurrency:
+            group: deploy-dev
+            queue: max
         secrets: inherit
         with:
             cluster: dev-gcp
@@ -99,7 +104,9 @@ jobs:
             id-token: write
         needs: [ publiser-kontrakt, dev ]
         uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
-        concurrency: deploy-prod
+        concurrency:
+            group: deploy-prod
+            queue: max
         secrets: inherit
         with:
             cluster: prod-gcp


### PR DESCRIPTION
## Problem
When merging several dependabot PRs in quick succession, one of the deploys often fails.

Job-level `concurrency` groups (`deploy-dev`, `deploy-prod`) used the default `queue: single` behavior, which **cancels a pending run** whenever a newer run is queued in the same group. Each new merge queues a new deploy and cancels the previous one's still-pending deploy job \u2014 showing up as a failed/cancelled deploy.

## Fix
- `release.yaml`: add `queue: max` to the `dev` and `prod` deploy jobs so queued deploys run sequentially (FIFO) instead of cancelling each other.
- `release.yaml`: add a concurrency group to `publiser-kontrakt` to avoid racing semantic-version tag computation across concurrent runs.
- `deploy-kafka.yaml`: add a workflow-level concurrency group (previously had none), to serialize kafka topic deploys.

`queue: max` requires `cancel-in-progress: false` (the default), which these jobs already use.